### PR TITLE
先生資料に基づき床下空調ロジックの更新(06/14)

### DIFF
--- a/src/jjjexperiment/constants.py
+++ b/src/jjjexperiment/constants.py
@@ -5,7 +5,7 @@ def version_info() -> str:
   """
   # NOTE: subprocessモジュールによるコミット履歴からの生成は \
   # ipynb 環境では正常に動作しないことを確認しました(returned no-zero exit status 128.)
-  return '_20240604'
+  return '_20240613'
 
 # FIXME: このデコレータの定義箇所どこが最適か
 # NOTE: 関数ラベリング用のデコレータ ex. @jjjexperiment_fork()

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -571,14 +571,14 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
             L_star_CS_d_t_i = \
                 dc.get_L_star_newuf_CS_d_t_i(L_CS_d_t_i, Q_star_trs_prt_d_t_i, region,
                         A_A, A_MR, A_OR, Q, r_A_ufac, underfloor_insulation, Theta_uf_d_t_2023,
-                        Theta_ex_d_t, V_dash_supply_d_t_i, L_dash_H_R_d_t_i, L_dash_CS_R_d_t_i, R_g, di)
+                        Theta_ex_d_t, V_dash_supply_d_t_i, L_dash_H_R_d_t_i, L_dash_CS_R_d_t_i, Theta_star_HBR_d_t, R_g, di)
 
             # (8')　熱損失を含む負荷バランス時の暖房負荷
             # 暖房負荷を補正する(暖房負荷 - 床下への損失 + 床下からの地盤への熱損失 + 床下から外気への熱損失)
             L_star_H_d_t_i = \
                 dc.get_L_star_newuf_H_d_t_i(L_H_d_t_i, Q_star_trs_prt_d_t_i, region,
                         A_A, A_MR, A_OR, Q, r_A_ufac, underfloor_insulation, Theta_uf_d_t_2023,
-                        Theta_ex_d_t, V_dash_supply_d_t_i, L_dash_H_R_d_t_i, L_dash_CS_R_d_t_i, R_g, di)
+                        Theta_ex_d_t, V_dash_supply_d_t_i, L_dash_H_R_d_t_i, L_dash_CS_R_d_t_i, Theta_star_HBR_d_t, R_g, di)
 
             # 床下空調 新ロジック 調査用出力ファイル
             survey_df_uf = di.get(UfVarsDataFrame)

--- a/src/pyhees/section3_1_e.py
+++ b/src/pyhees/section3_1_e.py
@@ -394,9 +394,9 @@ def calc_Theta(region, A_A, A_MR, A_OR, Q, r_A_ufvnt, underfloor_insulation, The
       Theta_dash_g_surf_A_m_d_t: 日付dの時刻tにおける指数項mの吸熱応答の項別成分 (℃)
       L_uf: 当該住戸の外気を導入する床下空間の基礎外周長さ
       H_floor: 床の温度差係数 (-)
-      phi: 基礎潜熱
-      Phi_A_0: 吸熱応答係数の初項
-      H_star_d_t_i: -
+      psi: Ψ基礎の線熱貫流率 (W/m2*K)
+      Phi_A_0: 吸熱応答係数の初項 (m2*K/W)
+      H_star_d_t_i: 温度差係数 (-)
       Theta_star_d_t_i: -
       Theta_supply_d_t: 日付dの時刻tにおける暖冷房区画iの吹き出し温度 (℃)
 
@@ -493,8 +493,8 @@ def calc_Theta(region, A_A, A_MR, A_OR, Q, r_A_ufvnt, underfloor_insulation, The
 
     H_floor = 0.7
 
-    # 基礎の線熱貫流率 (W/mK) (5)
-    phi = get_phi(region, Q)
+    # 基礎の線熱貫流率Ψ (W/m*K) (5)
+    psi = get_phi(region, Q)
 
     Theta_star = np.zeros(12)
     H_star = np.zeros(12)
@@ -533,12 +533,12 @@ def calc_Theta(region, A_A, A_MR, A_OR, Q, r_A_ufvnt, underfloor_insulation, The
           # 当該住宅の床下温度 (1)
           theta_uf = (ro_air * c_p_air * V_sa_d_t_A[dt] * theta_sa
                         + (sum([U_s * A_s_ufvnt[i - 1] * H_star[i - 1] * Theta_star[i - 1] for i in range(1, endi+1)])
-                          + phi * L_uf * Theta_ex_d_t[dt]
+                          + psi * L_uf * Theta_ex_d_t[dt]
                           + (A_s_ufvnt_A / R_g)
                             * (sum(Theta_dash_g_surf_A_m) + Theta_g_avg) / (1.0 + Phi_A_0 / R_g)) * 3.6) \
                       / (ro_air * c_p_air * V_sa_d_t_A[dt]
                         + (sum([U_s * A_s_ufvnt[i - 1] * H_star[i - 1] for i in range(1, endi+1)])
-                          + phi * L_uf
+                          + psi * L_uf
                           + (A_s_ufvnt_A / R_g)
                             * (1.0 / (1.0 + Phi_A_0 / R_g))) * 3.6)
           return theta_uf
@@ -617,7 +617,7 @@ def calc_Theta(region, A_A, A_MR, A_OR, Q, r_A_ufvnt, underfloor_insulation, The
           f"Theta_uf_d_t": Theta_uf_d_t,
         })
 
-    return Theta_uf_d_t, Theta_g_surf_d_t, A_s_ufvnt, A_s_ufvnt_A, Theta_g_avg, Theta_dash_g_surf_A_m_d_t, L_uf, H_floor, phi, Phi_A_0, H_star_d_t_i, Theta_star_d_t_i, Theta_supply_d_t
+    return Theta_uf_d_t, Theta_g_surf_d_t, A_s_ufvnt, A_s_ufvnt_A, Theta_g_avg, Theta_dash_g_surf_A_m_d_t, L_uf, H_floor, psi, Phi_A_0, H_star_d_t_i, Theta_star_d_t_i, Theta_supply_d_t
 
 @log_res(['Theta_uf_d_t'])
 def calc_Theta_uf_d_t_2023(L_H_d_t_i, L_CS_d_t_i, A_A, A_MR, A_OR, r_A_ufvnt, V_dash_supply_d_t_i, Theta_ex_d_t):


### PR DESCRIPTION
使用したパワポ：
240611_床下の計算法について_r3

# 主な内容：

(8), (9) 式における、床下に関する負荷の補正ロジックを修正

出力されるエクセルにおいて、
L*_H_d_t_1 がパワポの値に近しくなることを確認できています。

添付ファイル：出力されるエクセルの例として
[default_20240613_H_output_uf.csv](https://github.com/user-attachments/files/15831492/default_20240613_H_output_uf.csv)
