### PR TITLE
従来式のフィルター・キャップ式を改変式にも追加

### DIFF
--- a/src/jjjexperiment/ac_min_volume_input/section4_2.py
+++ b/src/jjjexperiment/ac_min_volume_input/section4_2.py
@@ -12,6 +12,7 @@ def get_V_hs_min_H(V_vent_g_i: Array5) -> float:
 def get_V_hs_min_C(V_vent_g_i: Array5) -> float:
     return get_V_hs_min(None, 1, V_vent_g_i)
 
+@jjj_cloning
 def get_V_hs_min(
         q_hs_rtd_H: float,
         q_hs_rtd_C: float,
@@ -49,6 +50,7 @@ def get_V_hs_min(
             raise Exception('q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提としています')
     return V_hs_min
 
+@jjj_cloning
 def get_V_hs_vent_d_t(
         q_hs_rtd_H: float,
         q_hs_rtd_C: float,
@@ -75,13 +77,16 @@ def get_V_hs_vent_d_t(
 
     app_config = injector.get(AppConfig)
 
-    # 暖房時/冷房時
-    if q_hs_rtd_H is not None:
-        input_V_hs_min = app_config.input_V_hs_min_H
-    elif q_hs_rtd_C is not None:
-        input_V_hs_min = app_config.input_V_hs_min_C
-    else:
-        raise Exception('q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提としています')
+    # 暖房期/冷房期 判別
+    match(q_hs_rtd_H, q_hs_rtd_C):
+        case(None, None):
+            raise Exception('q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提')
+        case(_, None):
+            input_V_hs_min = app_config.input_V_hs_min_H
+        case(None, _):
+            input_V_hs_min = app_config.input_V_hs_min_C
+        case(_, _):
+            raise Exception('q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提')
 
     # 全般換気の機能を有する場合
     if general_ventilation == True:

--- a/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
+++ b/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
@@ -11,7 +11,8 @@ def get_E_E_fan_d_t(
         P_fan_rtd: float,
         V_hs_vent_d_t: Array8760,
         V_hs_supply_d_t: Array8760,
-        V_hs_dsgn: float
+        V_hs_dsgn: float,
+        q_hs_d_t: Array8760
         ) -> Array8760:
     """(37)改 暖冷房送風機消費電力
 
@@ -28,8 +29,12 @@ def get_E_E_fan_d_t(
     E_E_fan_1_d_t = P_fan_rtd * (V_hs_supply_d_t / V_hs_dsgn) * 10 ** (-3)
     E_E_fan_2_d_t = P_fan_rtd * (V_hs_vent_d_t / V_hs_dsgn) * 10 ** (-3)
 
-    assert E_E_fan_1_d_t.shape == (8760,), "Invalid Shape: E_E_fan_H1_d_t"
-    assert E_E_fan_2_d_t.shape == (8760,), "Invalid Shape: E_E_fan_H2_d_t"
+    assert E_E_fan_1_d_t.shape == (8760,), "想定外の行列数"
+    assert E_E_fan_2_d_t.shape == (8760,), "想定外の行列数"
 
-    E_E_fan_H_d_t = np.maximum(E_E_fan_1_d_t, E_E_fan_2_d_t)
+    E_E_fan_H_d_t = np.zeros(24 * 365)
+    E_E_fan_H_d_t[q_hs_d_t > 0]  \
+        = np.maximum(E_E_fan_1_d_t, E_E_fan_2_d_t)[q_hs_d_t > 0]
+
+    assert E_E_fan_H_d_t.shape == (8760,), "想定外の行列数"
     return E_E_fan_H_d_t

--- a/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
+++ b/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
@@ -5,6 +5,7 @@ from jjjexperiment.common import *
 # A.6 送風機
 # ============================================================================
 
+@jjj_cloning
 def get_E_E_fan_d_t(
         P_fan_rtd: float,
         V_hs_vent_d_t: Array8760,

--- a/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
+++ b/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
@@ -1,4 +1,5 @@
 import numpy as np
+# JJJ
 from jjjexperiment.common import *
 
 # ============================================================================

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -611,12 +611,16 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                             Theta_req_d_t_i[i], Theta_ex_d_t, V_dash_supply_d_t_i[i],
                             '', L_H_d_t_i, L_CS_d_t_i)
 
-                    if q_hs_rtd_H is not None:
-                        mask = Theta_req_d_t_i[i] > Theta_uf_d_t
-                    elif q_hs_rtd_C is not None:
-                        mask = Theta_req_d_t_i[i] < Theta_uf_d_t
-                    else:
-                        raise IOError("冷房時・暖房時の判断に失敗しました。")
+                    # 暖冷房期 判別
+                    match(q_hs_rtd_H, q_hs_rtd_C):
+                        case (None, None):
+                            raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
+                        case (_, None):  # 暖房期
+                            mask = Theta_req_d_t_i[i] > Theta_uf_d_t
+                        case (None, _):  # 冷房期
+                            mask = Theta_req_d_t_i[i] < Theta_uf_d_t
+                        case (_, _):
+                            raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
                     Theta_req_d_t_i[i] = np.where(mask,
                                                   Theta_req_d_t_i[i] + (Theta_req_d_t_i[i] - Theta_uf_d_t),
@@ -658,12 +662,15 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                             Theta_supply_d_t_i[i], Theta_ex_d_t, V_dash_supply_d_t_i[i],
                             '', L_H_d_t_i, L_CS_d_t_i)
 
-                    if q_hs_rtd_H is not None:
-                        mask = Theta_supply_d_t_i[i] > Theta_uf_d_t
-                    elif q_hs_rtd_C is not None:
-                        mask = Theta_supply_d_t_i[i] < Theta_uf_d_t
-                    else:
-                        raise IOError("冷房時・暖房時の判断に失敗しました。")
+                    match(q_hs_rtd_H, q_hs_rtd_C):
+                        case (None, None):
+                            raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
+                        case (_, None):  # 暖房期
+                            mask = Theta_supply_d_t_i[i] > Theta_uf_d_t
+                        case (None, _):  # 冷房期
+                            mask = Theta_supply_d_t_i[i] < Theta_uf_d_t
+                        case (_, _):
+                            raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
                     Theta_supply_d_t_i[i] = np.where(mask, Theta_uf_d_t, Theta_supply_d_t_i[i])
 
@@ -902,17 +909,22 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                         Theta_req_d_t_i[i], Theta_ex_d_t, V_dash_supply_d_t_i[i],
                         '', L_H_d_t_i, L_CS_d_t_i)
 
-                if q_hs_rtd_H is not None:  # 暖房
-                  mask = Theta_req_d_t_i[i] > Theta_uf_d_t
-                elif q_hs_rtd_C is not None:  # 冷房
-                  mask = Theta_req_d_t_i[i] < Theta_uf_d_t
-                else:
-                    raise IOError("冷房時・暖房時の判断に失敗しました。")
+                match(q_hs_rtd_H, q_hs_rtd_C):
+                    case(None, None):
+                        raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
+                    case(_, None):  # 暖房
+                        mask = Theta_req_d_t_i[i] > Theta_uf_d_t
+                    case(None, _):  # 冷房
+                        mask = Theta_req_d_t_i[i] < Theta_uf_d_t
+                    case(_, _):
+                        raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
-                Theta_req_d_t_i[i] = np.where(mask,
-                                            # 熱源機出口 -> 居室床下までの温度低下分を見込む
-                                            Theta_req_d_t_i[i] + (Theta_req_d_t_i[i] - Theta_uf_d_t),
-                                            Theta_req_d_t_i[i])
+                Theta_req_d_t_i[i]  \
+                    = np.where(mask,
+                            # 熱源機出口 -> 居室床下までの温度低下分を見込む
+                            Theta_req_d_t_i[i] + (Theta_req_d_t_i[i] - Theta_uf_d_t),
+                            Theta_req_d_t_i[i])
+
             assert np.shape(Theta_req_d_t_i)==(5, 8760), "想定外の行列数です"
 
         # (15)　熱源機の出口における絶対湿度
@@ -977,12 +989,15 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                         Theta_supply_d_t_i[i], Theta_ex_d_t, V_dash_supply_d_t_i[i],
                         '', L_H_d_t_i, L_CS_d_t_i)
 
-                if q_hs_rtd_H is not None:  # 暖房
-                    mask = Theta_supply_d_t_i[i] > Theta_uf_d_t
-                elif q_hs_rtd_C is not None:  # 冷房
-                    mask = Theta_supply_d_t_i[i] < Theta_uf_d_t
-                else:
-                    raise IOError("冷房時・暖房時の判断に失敗しました。")
+                match(q_hs_rtd_H, q_hs_rtd_C):
+                    case (None, None):
+                        raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
+                    case (_, None):  # 暖房
+                        mask = Theta_supply_d_t_i[i] > Theta_uf_d_t
+                    case (None, _):  # 冷房
+                        mask = Theta_supply_d_t_i[i] < Theta_uf_d_t
+                    case (_, _):
+                        raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
                 Theta_supply_d_t_i[i] = np.where(mask, Theta_uf_d_t, Theta_supply_d_t_i[i])
 
@@ -1059,12 +1074,19 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
             carryovers_i_4 = carryovers[3],
             carryovers_i_5 = carryovers[4]
         )
-        if q_hs_rtd_H is not None and q_hs_rtd_C is None:
-            df_carryover_output.to_csv(case_name + jjj_consts.version_info() + '_H_carryover_output.csv', encoding = 'cp932')
-        elif q_hs_rtd_C is not None and q_hs_rtd_H is None:
-            df_carryover_output.to_csv(case_name + jjj_consts.version_info() + '_C_carryover_output.csv', encoding = 'cp932')
-        else:
-            raise IOError("冷房時・暖房時の判断に失敗しました。")
+        match (q_hs_rtd_H, q_hs_rtd_C):
+            case (None, None):
+                raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
+            case (_, None):
+                df_carryover_output.to_csv(
+                    case_name + jjj_consts.version_info() + '_H_carryover_output.csv',
+                    encoding = 'cp932')
+            case (None, _):
+                df_carryover_output.to_csv(
+                    case_name + jjj_consts.version_info() + '_C_carryover_output.csv',
+                    encoding = 'cp932')
+            case (_, _):
+                raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
     """ 熱損失・熱取得を含む負荷バランス時の熱負荷 - 熱損失・熱取得を含む負荷バランス時(2) """
     df_output = df_output.assign(
@@ -1196,6 +1218,7 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
 
     """ 熱源機の入口 - 熱源機の風量の計算 """
     # (35)　熱源機の風量のうちの全般換気分
+    # TODO: ここでは従来式を使用するらしい
     V_hs_vent_d_t \
         = jjj_V_min_input.get_V_hs_vent_d_t(
             q_hs_rtd_H, q_hs_rtd_C, region,
@@ -1285,14 +1308,20 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
         survey_df_uf = di.get(UfVarsDataFrame)  # ネスト関数内で更新されているデータフレーム
         survey_df_uf.export_to_csv(filename)
 
-    if q_hs_rtd_H is not None:
-        df_output3.to_csv(case_name + jjj_consts.version_info() + '_H_output3.csv', encoding = 'cp932')
-        df_output2.to_csv(case_name + jjj_consts.version_info() + '_H_output4.csv', encoding = 'cp932')
-        df_output.to_csv(case_name  + jjj_consts.version_info() + '_H_output5.csv', encoding = 'cp932')
-    else:
-        df_output3.to_csv(case_name + jjj_consts.version_info() + '_C_output3.csv', encoding = 'cp932')
-        df_output2.to_csv(case_name + jjj_consts.version_info() + '_C_output4.csv', encoding = 'cp932')
-        df_output.to_csv(case_name  + jjj_consts.version_info() + '_C_output5.csv', encoding = 'cp932')
+    match(q_hs_rtd_H, q_hs_rtd_C):
+        case(None, None):
+            raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
+        case(_, None):
+            df_output3.to_csv(case_name + jjj_consts.version_info() + '_H_output3.csv', encoding = 'cp932')
+            df_output2.to_csv(case_name + jjj_consts.version_info() + '_H_output4.csv', encoding = 'cp932')
+            df_output.to_csv(case_name  + jjj_consts.version_info() + '_H_output5.csv', encoding = 'cp932')
+        case(None, _):
+            df_output3.to_csv(case_name + jjj_consts.version_info() + '_C_output3.csv', encoding = 'cp932')
+            df_output2.to_csv(case_name + jjj_consts.version_info() + '_C_output4.csv', encoding = 'cp932')
+            df_output.to_csv(case_name  + jjj_consts.version_info() + '_C_output5.csv', encoding = 'cp932')
+        case(_, _):
+            raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
-    return E_C_UT_d_t, Q_UT_H_d_t_i, Q_UT_CS_d_t_i, Q_UT_CL_d_t_i, Theta_hs_out_d_t, Theta_hs_in_d_t, Theta_ex_d_t, \
-           X_hs_out_d_t, X_hs_in_d_t, V_hs_supply_d_t, V_hs_vent_d_t, C_df_H_d_t
+    return E_C_UT_d_t, Q_UT_H_d_t_i, Q_UT_CS_d_t_i, Q_UT_CL_d_t_i,  \
+            Theta_hs_out_d_t, Theta_hs_in_d_t, Theta_ex_d_t,  \
+            X_hs_out_d_t, X_hs_in_d_t, V_hs_supply_d_t, V_hs_vent_d_t, C_df_H_d_t

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -622,9 +622,10 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                         case (_, _):
                             raise Exception("q_hs_rtd_H, q_hs_rtd_C はどちらかのみを前提")
 
-                    Theta_req_d_t_i[i] = np.where(mask,
-                                                  Theta_req_d_t_i[i] + (Theta_req_d_t_i[i] - Theta_uf_d_t),
-                                                  Theta_req_d_t_i[i])
+                    Theta_req_d_t_i[i]  \
+                        = np.where(mask,
+                                Theta_req_d_t_i[i] + (Theta_req_d_t_i[i] - Theta_uf_d_t),
+                                Theta_req_d_t_i[i])
 
             # NOTE: 過剰熱量繰越 未利用の場合では、式(14)(46)(48)の条件に合わせてTheta_NR_d_tを初期化
             # Theta_NR_d_t = np.zeros(24 * 365)

--- a/src/jjjexperiment/section4_2_a.py
+++ b/src/jjjexperiment/section4_2_a.py
@@ -34,13 +34,14 @@ def calc_E_E_fan_H_d_t(
 
     # (37) 送風機の付加分 [kWh/h]
     if app_config.input_V_hs_min_H == 最低風量直接入力.入力する.value:
-        E_E_fan_H_d_t \
+        E_E_fan_H_d_t  \
             = jjj_V_min_input.get_E_E_fan_d_t(
                 P_rac_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_H)
+        # TODO: 改変式の方も同様に q_hs_H_d_t でのフィルタを使用すべきか確認中
 
     elif app_config.input_V_hs_min_H == 最低風量直接入力.入力しない.value:
         # デフォルト条件では V_hs_vent_d_t は既存式(35)のまま
-        E_E_fan_H_d_t \
+        E_E_fan_H_d_t  \
             = dc_a.get_E_E_fan_H_d_t(type,
                     # NOTE: ルームエアコンファン(P_rac_fan) / 循環ファン(P_fan) 切替
                     P_rac_fan_rtd_H if type == PROCESS_TYPE_2 else P_fan_rtd_H,

--- a/src/jjjexperiment/underfloor_ac/section4_2_f46_f48.py
+++ b/src/jjjexperiment/underfloor_ac/section4_2_f46_f48.py
@@ -52,8 +52,7 @@ def get_Theta_HBR_i(
                     / (CRV
                         + (U_prt * A_prt_i + Q * A_HCZ_i) * 3600
                         + U_s * A_s_ufac_i * 3600)  ##
-            # return np.clip(Theta_HBR_i, Theta_star_HBR, None)
-            return Theta_HBR_i
+            return np.clip(Theta_HBR_i, Theta_star_HBR, None)
 
         # 冷房期 (46-2)
         case JJJ_HCM.C:
@@ -64,8 +63,7 @@ def get_Theta_HBR_i(
                     / (CRV
                         + (U_prt * A_prt_i + Q * A_HCZ_i) * 3600
                         + U_s * A_s_ufac_i * 3600)  ##
-            # return np.clip(Theta_HBR_i, None, Theta_star_HBR)
-            return Theta_HBR_i
+            return np.clip(Theta_HBR_i, None, Theta_star_HBR)
 
         # 中間期 (46-3)
         case JJJ_HCM.M:

--- a/src/jjjexperiment/underfloor_ac/section4_2_f46_f48.py
+++ b/src/jjjexperiment/underfloor_ac/section4_2_f46_f48.py
@@ -52,7 +52,9 @@ def get_Theta_HBR_i(
                     / (CRV
                         + (U_prt * A_prt_i + Q * A_HCZ_i) * 3600
                         + U_s * A_s_ufac_i * 3600)  ##
-            return np.clip(Theta_HBR_i, Theta_star_HBR, None)
+            # NOTE: 仕様書の計算例にはなかったためテストの値修正も必要
+            # return np.clip(Theta_HBR_i, Theta_star_HBR, None)
+            return Theta_HBR_i
 
         # 冷房期 (46-2)
         case JJJ_HCM.C:
@@ -64,6 +66,7 @@ def get_Theta_HBR_i(
                         + (U_prt * A_prt_i + Q * A_HCZ_i) * 3600
                         + U_s * A_s_ufac_i * 3600)  ##
             return np.clip(Theta_HBR_i, None, Theta_star_HBR)
+            return Theta_HBR_i
 
         # 中間期 (46-3)
         case JJJ_HCM.M:

--- a/src/pyhees/section4_2.py
+++ b/src/pyhees/section4_2.py
@@ -1339,6 +1339,7 @@ def get_V_hs_supply_d_t(V_supply_d_t_i):
     return np.sum(V_supply_d_t_i[:5, :], axis=0)
 
 
+@jjj_cloned
 def get_V_hs_vent_d_t(V_vent_g_i, general_ventilation):
     """(35-1)(35-2)
 

--- a/src/pyhees/section4_2.py
+++ b/src/pyhees/section4_2.py
@@ -2019,7 +2019,8 @@ def get_r_supply_des_d_t_i_2023(region, L_CS_d_t_i, L_H_d_t_i):
 # 11.1 実際の居室の室温・絶対湿度
 # ============================================================================
 
-@jjj_cloned
+@jjj_cloned  # carryover_heat
+@jjj_cloned  # underfloor_ac
 def get_Theta_HBR_d_t_i(Theta_star_HBR_d_t, V_supply_d_t_i, Theta_supply_d_t_i, U_prt, A_prt_i, Q, A_HCZ_i, L_star_H_d_t_i, L_star_CS_d_t_i, region):
     """(46-1)(46-2)(46-3)
 
@@ -2087,6 +2088,7 @@ def get_X_HBR_d_t_i(X_star_HBR_d_t):
 # ============================================================================
 
 @jjj_cloned  # underfloor_ac/section4_2/get_Theta_NR
+@jjj_cloned  # carryover_heat
 def get_Theta_NR_d_t(Theta_star_NR_d_t, Theta_star_HBR_d_t, Theta_HBR_d_t_i, A_NR, V_vent_l_NR_d_t, V_dash_supply_d_t_i, V_supply_d_t_i, U_prt, A_prt_i, Q):
     """(48a)(48b)(48c)(48d)
 

--- a/src/pyhees/section4_2_a.py
+++ b/src/pyhees/section4_2_a.py
@@ -1427,6 +1427,7 @@ def get_A_e_hex(type, q_hs_rtd_C):
 # A.6 送風機
 # ============================================================================
 
+@jjj_cloned  # ac_min_volume_input
 def get_E_E_fan_H_d_t(type, P_fan_rtd_H, V_hs_vent_d_t, V_hs_supply_d_t, V_hs_dsgn_H, q_hs_H_d_t, f_SFP = None):
     """(37)
 


### PR DESCRIPTION
@iguchi-lab  先生

# 対応内容

最小風量入力時に、従来式のフィルタロジックを追加していないと、
暖房期に冷房期の消費電力が入り込んでしまうバグが報告されたため、
従来式同様のフィルタロジックを改変式にも適用しました。

BOFORE:

![スクリーンショット 2025-04-11 105827](https://github.com/user-attachments/assets/b14483d4-6b09-4742-a625-38cce89bf4f4)

AFTER:

![スクリーンショット 2025-04-11 105414](https://github.com/user-attachments/assets/29616587-4512-411e-8fdf-b3315138a12f)

