### PR TITLE
過剰熱量繰越の調整

### DIFF
--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -7,8 +7,8 @@ import jjjexperiment.carryover_heat as jjj_carryover_heat
 from jjjexperiment.logger import log_res
 
 def calc_carryover(
-        H: bool,
-        C: bool,
+        H: np.bool,
+        C: np.bool,
         A_HCZ_i: Array5,
         Theta_HBR_i: Array5x1,
         Theta_star_HBR: float,
@@ -31,18 +31,20 @@ def calc_carryover(
     cbri = jjj_carryover_heat.get_C_BR_i(A_HCZ_i)
 
     # 季節の判断
-    if H and C:
-        raise ValueError("想定外の季節")
-    # 暖冷房ともに有効であれば正となるように算出
-    elif H:
-        # 過剰熱量がない部屋は負の過剰熱量にならないようクリップする
-        temperature_diff = np.clip(Theta_HBR_i - Theta_star_HBR, 0, None)
-    elif C:
-        # 過剰熱量がない部屋は負の過剰熱量にならないようクリップする
-        temperature_diff = np.clip(Theta_star_HBR - Theta_HBR_i, 0, None)
-    else:
-        # 空調なし -> 過剰熱量なし
-        return np.zeros((5, 1))
+    match (H, C):
+        case (np.True_, np.True_):
+            raise ValueError("想定外の季節")
+        case (np.True_, np.False_):
+            # 過剰熱量がない部屋は負の過剰熱量にならないようクリップする
+            temperature_diff = np.clip(Theta_HBR_i - Theta_star_HBR, 0, None)
+        case (np.False_, np.True_):
+            # 過剰熱量がない部屋は負の過剰熱量にならないようクリップする
+            temperature_diff = np.clip(Theta_star_HBR - Theta_HBR_i, 0, None)
+        case (np.False_, np.False_):
+            # 空調なし -> 過剰熱量なし
+            return np.zeros((5, 1))
+        case _:
+            raise ValueError("判別に失敗")
 
     # 事後条件:
     assert np.all(0 <= cbri), "居室の熱容量は負にならない"
@@ -255,6 +257,7 @@ def get_Theta_NR_2023(
 
     val1 = -1 * np.sum(k_prt_dash_i) * (Theta_star_HBR - Theta_star_NR)
     val2 = np.sum(k_prt_i * (Theta_HBR_i - Theta_star_NR))
+    val3 = k_evp + np.sum(k_prt_i)
 
     # 過剰熱量発生条件
     H = H and (Theta_NR_before >= Theta_star_NR)
@@ -275,14 +278,10 @@ def get_Theta_NR_2023(
         ac_theta_diff = 0  # 使用されないが定義は必要
         pass
 
-    # val3, 4 は同じ条件で有効・無効切替
-    val3 = ac_theta_diff \
-        * (0 if (isFirst or not (H or C)) else jjj_carryover_heat.get_C_NR(A_NR) / 3600)
-    val4 = k_evp + np.sum(k_prt_i) \
-        + (0 if (isFirst or not (H or C)) else jjj_carryover_heat.get_C_NR(A_NR) / 3600)
-
     # (48a) NOTE: isFirst と過剰熱量無効のとき元式と一致するべき
-    Theta_NR = Theta_star_NR + (val1 + val2 + val3) / val4
+    C_NR = 0 if isFirst or not (H or C)  \
+        else jjj_carryover_heat.get_C_NR(A_NR) / 3600
+    Theta_NR = Theta_star_NR + (val1 + val2 + ac_theta_diff * C_NR) / (val3 + C_NR)
 
     # TODO: Theta_NR が単増加してしまう問題がある
     # -> 過剰熱量持越しの追い空調の停止条件を追加することが考えられる

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -516,16 +516,16 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                 carryover = np.zeros((5, 1))
             # 暖房期 前時刻にて 暖かさに余裕があるとき
             elif H[t] and np.any(Theta_HBR_d_t_i[:, t-1:t] > Theta_star_HBR_d_t[t-1]):
-                carryover = jjj_carryover_heat \
-                    .calc_carryover(H[t], C[t], A_HCZ_i,
+                carryover = jjj_carryover_heat.calc_carryover(
+                                    H[t], C[t], A_HCZ_i,
                                     Theta_HBR_d_t_i[:, t-1:t],
-                                    Theta_star_HBR_d_t[t-1])
+                                    Theta_star_HBR_d_t[t])
             # 冷房期 前時刻にて 涼しさに余裕があるとき
             elif C[t] and np.any(Theta_HBR_d_t_i[:, t-1:t] < Theta_star_HBR_d_t[t-1]):
-                carryover = jjj_carryover_heat \
-                    .calc_carryover(H[t], C[t], A_HCZ_i,
+                carryover = jjj_carryover_heat.calc_carryover(
+                                    H[t], C[t], A_HCZ_i,
                                     Theta_HBR_d_t_i[:, t-1:t],
-                                    Theta_star_HBR_d_t[t-1])
+                                    Theta_star_HBR_d_t[t])
             else:
                 carryover = np.zeros((5, 1))
                 # 前時刻の Theta_HBR_d_t_i を使用するため


### PR DESCRIPTION
# したこと

・負の過剰熱量を許容する仕様へ変更しました。

クリッピングをしないように変更しました。

![スクリーンショット 2025-04-17 114054](https://github.com/user-attachments/assets/9ea16260-197d-401b-a85f-f18fcde34929)

・熱繰越ループのインデックスを調整しました。

過剰熱量繰越の有無判別：θ＊HBR[t-1]　θHBR[t-1]
温度差の計算時　　　　：θ＊HBR[t]   　θHBR[t-1]
仕様書に合わせました。

![スクリーンショット 2025-04-17 114633](https://github.com/user-attachments/assets/5a471b82-e0b8-43c5-b6fc-2101169f1647)

![スクリーンショット 2025-04-17 114213](https://github.com/user-attachments/assets/b531adc6-2045-438c-a174-62b4d9e8e27e)

よろしくお願いします @iguchi-lab  先生
暖房期・冷房期の式切替については、問題ないことを確認しました。
