### PR TITLE
fix: 床下空調(40)の先頭の符号切替は変数に内包されていた

### DIFF
--- a/src/jjjexperiment/underfloor_ac/section4_2.py
+++ b/src/jjjexperiment/underfloor_ac/section4_2.py
@@ -78,7 +78,6 @@ def calc_Theta_uf(
 
     # TODO: sympy の方程式で記述できればコードの意味が理解しやすくなる
     b = ro_air * c_p_air * V_flr1st + U_s_vert * A_s_ufvnt * 3.6
-    a1 = L_flr1st * 1e+3
 
     match (q_hs_rtd_H, q_hs_rtd_C):
         case (None, None):
@@ -87,13 +86,15 @@ def calc_Theta_uf(
         case (_, None):  # 暖房期
             delta_Theta = max(Theta_in - Theta_ex, 0)
             a2 = U_s_vert * A_s_ufvnt * delta_Theta * H_floor * 3.6
-            Theta_uf = (a1 - a2 + Theta_in * b) / b
+            assert L_flr1st >= 0, "暖房期の負荷は正の値"
+            Theta_uf = (L_flr1st * 1e+3 - a2 + Theta_in * b) / b
             return Theta_uf
 
         case (None, _):  # 冷房期
             delta_Theta = max(Theta_ex - Theta_in, 0)
             a2 = U_s_vert * A_s_ufvnt * delta_Theta * H_floor * 3.6
-            Theta_uf = (-1 * a1 + a2 + Theta_in * b) / b
+            assert L_flr1st <= 0, "冷房期の負荷は負の値"
+            Theta_uf = (L_flr1st * 1e+3 + a2 + Theta_in * b) / b
             return Theta_uf
 
         case (_, _):


### PR DESCRIPTION
# おこなったこと @iguchi-lab  先生

式(40) の符号切替対応、先頭の項には、変数自体に正負が内包されていたため対応不要だったのを戻します。
assert 分でその旨を確認するコードとなっています。

![スクリーンショット 2025-04-23 204607](https://github.com/user-attachments/assets/203b9478-52a2-408e-aed5-1dbc508c1109)

これでもう 160 にはなりませんことを確認しました。
