### PR TITLE
過剰熱量繰越式中の意図しない絶対値算定を除外

### DIFF
--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -172,6 +172,8 @@ def get_Theta_HBR_i_2023(
     # 熱容量(居室) [J/K]
     cbri = jjj_carryover_heat.get_C_BR_i(A_HCZ_i)
 
+    # TODO: 250625 梅本様よりコメントで絶対値としないのが正しいとのこと
+
     carryover_theta_diff = np.abs(Theta_HBR_before_i - Theta_star_HBR)
     # 熱繰越による熱容量[J] (1/1/0:00 なしとする)
     carryover_capacity = 0 if isFirst else cbri * carryover_theta_diff

--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -172,9 +172,9 @@ def get_Theta_HBR_i_2023(
     # 熱容量(居室) [J/K]
     cbri = jjj_carryover_heat.get_C_BR_i(A_HCZ_i)
 
-    # TODO: 250625 梅本様よりコメントで絶対値としないのが正しいとのこと
+    # NOTE: 250625 梅本様より絶対値を外すよう指摘に対応しました
+    carryover_theta_diff = Theta_HBR_before_i - Theta_star_HBR
 
-    carryover_theta_diff = np.abs(Theta_HBR_before_i - Theta_star_HBR)
     # 熱繰越による熱容量[J] (1/1/0:00 なしとする)
     carryover_capacity = 0 if isFirst else cbri * carryover_theta_diff
 

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -414,8 +414,6 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
         A_prt_A = np.sum(A_prt_i)
         HCM = np.array(jjj_ipt.ClimateEntity(region).get_HCM_d_t())
 
-        Theta_NR_init = Theta_in_d_t[0]  # ここでは仮置き値(20 / 27)
-
         Theta_star_NR_d_t = np.vectorize(jjj_ufac.get_Theta_star_NR)
         Theta_star_NR_d_t  \
             = Theta_star_NR_d_t(
@@ -428,7 +426,7 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                 A_prt_A = A_prt_A,
                 L_H_NR_A = L_H_NR_d_t_A,  # (8760,)
                 L_CS_NR_A = L_CS_NR_d_t_A,  # (8760,)
-                Theta_NR = Theta_NR_init,
+                Theta_NR = 20,  # この時点では仮置きの値を使用
                 Theta_uf = Theta_uf_d_t,  # (8760,)
                 HCM = HCM  # (8760,)
             )

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -414,6 +414,8 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
         A_prt_A = np.sum(A_prt_i)
         HCM = np.array(jjj_ipt.ClimateEntity(region).get_HCM_d_t())
 
+        Theta_NR_init = Theta_in_d_t[0]  # ここでは仮置き値(20 / 27)
+
         Theta_star_NR_d_t = np.vectorize(jjj_ufac.get_Theta_star_NR)
         Theta_star_NR_d_t  \
             = Theta_star_NR_d_t(
@@ -426,7 +428,7 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                 A_prt_A = A_prt_A,
                 L_H_NR_A = L_H_NR_d_t_A,  # (8760,)
                 L_CS_NR_A = L_CS_NR_d_t_A,  # (8760,)
-                Theta_NR = 20,  # この時点では仮置きの値を使用
+                Theta_NR = Theta_NR_init,
                 Theta_uf = Theta_uf_d_t,  # (8760,)
                 HCM = HCM  # (8760,)
             )


### PR DESCRIPTION
ソースを眺めていて、気づいたのでプルリクを送信します。
θ*NR の計算時に仮置きする θNR が暖房時の数値で固定になっていました。

@iguchi-lab  先生